### PR TITLE
ci(core): update triggering repository path

### DIFF
--- a/stacks/cdkpipelines/pipeline.py
+++ b/stacks/cdkpipelines/pipeline.py
@@ -17,7 +17,7 @@ class CdkPipelineStack(cdk.Stack):
         self.pipeline =  CodePipeline(self, "Pipeline", 
                         synth=ShellStep("Synth", 
                             input=CodePipelineSource.connection(
-                                repo_string="pmkuny/aws-env", 
+                                repo_string="pmkuny/aws-env-development", 
                                 branch="develop", 
                                 connection_arn=self.connection_arn,
                                 trigger_on_push=True),


### PR DESCRIPTION
* Since we've split the old repository (that contained way too much
  code) into separate repositories, we need to update the 'repo_string'
  that CodeStar will use to detect changes to trigger our CDK Pipeline